### PR TITLE
Fix order cancellation wrong toast message fmh #85

### DIFF
--- a/src/components/common/order/CancelOrder.jsx
+++ b/src/components/common/order/CancelOrder.jsx
@@ -19,11 +19,11 @@ export default function CancelOrder({ orderId, isOpen, onClose }) {
       return;
     }
 
-    const toastId = toast.loading(t('cancelling_order_loading'));
+    const toastId = toast.loading(t('CANCELLING_ORDER_LOADING'));
     const { success, error } = await cancelOrder(orderId, reason);
     toast.dismiss(toastId);
     if (success) {
-      toast.success(i18n.t('order_cancelled_success'));
+      toast.success(i18n.t('ORDER_CANCELLED_SUCCESS'));
     } else {
       toast.error(error || t('ERROR_GENERAL'));
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -481,5 +481,6 @@
   "PICKED_UP": "Picked up",
   "SHAHBY_HOTEL": "Shahby hotel",
   "ZUHAK_RESTAURANT": "Zuhak Restaurant",
-  "GO_HOME": "Go home"
+  "GO_HOME": "Go home",
+  "NEW_EVENT_ARRIVED": "New event arrived"
 }

--- a/src/i18n/locales/fa.json
+++ b/src/i18n/locales/fa.json
@@ -478,5 +478,7 @@
   "SHAHBY_HOTEL": "هتل شاهبی",
   "ZUHAK_RESTAURANT": "رستورانت ضُحاک",
   "GO_HOME": "رفتن به خانه",
-  "ACTIVE": "Active"
+  "ACTIVE": "Active",
+  "NEW_EVENT_ARRIVED": "رویداد جدید دریافت شد"
+
 }

--- a/src/i18n/locales/ps.json
+++ b/src/i18n/locales/ps.json
@@ -480,5 +480,6 @@
   "PICKED_UP": "ترلاسه شوی",
   "SHAHBY_HOTEL": "شاهي هوټل",
   "ZUHAK_RESTAURANT": "رستورانت زُحاک",
-  "GO_HOME": "کور ته ځل"
+  "GO_HOME": "کور ته ځل",
+  "NEW_EVENT_ARRIVED": "نوې پېښه ترلاسه شوه"
 }

--- a/src/pages/public/auth/Login.jsx
+++ b/src/pages/public/auth/Login.jsx
@@ -50,7 +50,7 @@ const Login = () => {
     e.preventDefault();
     const result = await loginUser();
     if (result?.success) {
-      toast.success(t('WelcomeAgain'));
+      toast.success(t('WELCOME_AGAIN'));
       navigate('/', { replace: true });
     } else if (result?.type !== 'validation') {
       toast.error(result?.message || t('loginFailed'));

--- a/src/services/listener/notificationListener.js
+++ b/src/services/listener/notificationListener.js
@@ -8,8 +8,7 @@ export const notificationListener = () => {
   socket.on('notification', (data) => {
     useNotificationStore.getState().addNotification({
       id: data.orderId ?? Date.now(),
-      message: data.message || i18n.t('NEW_NOTIFICATION'),
+      message: data?.message || t("NEW_EVENT_ARRIVED"),
     });
-    toast.success(i18n.t('NEW_ORDER_CREATED'));
   });
 };


### PR DESCRIPTION
## Summary 

- In this pull request I used to inspect the reason behind duplicated and unrelated toast messages after the order cancellation. And fix the issue properly.
- The problem was that when an order was cancelled it was counted as an event called `notification` based on the system so the socket (and in some cases the firebase) used to emit the hardcoded toast message `New order created`, while it was in contrast with what console used to log and the notification inbox showed.
- I ensured that the problem is fixed and the exact message coming from backend is pushed after cancellation.

**Reviewers**
- [ ] Peer
- [x] Mentor

**Closes** #85