### PR TITLE
fix the duplicated phone number in driver table fmh #91

### DIFF
--- a/src/components/admin/driver-list/DriverTable.jsx
+++ b/src/components/admin/driver-list/DriverTable.jsx
@@ -237,7 +237,6 @@ export default function DriverTable({
               <td className="px-6 py-5 text-base text-black">
                 <div className="flex flex-col">
                   <span>{toLocaleDigits(driver.phone, lng)}</span>
-                  <span>{toLocaleDigits(driver.phone, lng)}</span>
                 </div>
               </td>
               <td className="px-6 py-5 text-base text-black max-w-[280px]">


### PR DESCRIPTION
## Summary 

- I used to find and delete the duplicated phone number in the driver table.

**Reviewers**
- [x] Peer

**Closes** #91 